### PR TITLE
🐛 checkout repo instead

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,9 +19,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repo 🛎
+        if: steps.download_artifact.outcome == 'failure'
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Run CI ⚙️
         if: steps.download_artifact.outcome == 'failure'
-        uses: ${{ github.repository }}/.github/workflows/ci.yml@main
+        uses: ./.github/workflows/ci.yml@main
 
       - name: Download artifact ⬇️
         if: steps.download_artifact.outcome == 'failure'


### PR DESCRIPTION
checkout repo instead. using github context in `uses:` does not seem to work.