### PR TITLE
🤖 Convert to GitHub Action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: sync
     steps:
-      - uses: bmiddha/calsync@main
+      - uses: acm-uic/calsync@main
         with:
           discord-guild-id: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID }}
           discord-bot-token: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,21 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     name: sync
     steps:
-      - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+      - uses: bmiddha/calsync@main
         with:
-          ref: main
-
-      - name: Setup Deno 🔧
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
-
-      - name: Run sync 🔁
-        run: deno run --allow-net --allow-env --allow-read ./mod.ts
-        env:
-          DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID }}
-          DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN }}
-          DISCORD_EVENTS_SYNC_DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_APPLICATION_ID }}
-          DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_CALENDAR_ID: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_CALENDAR_ID }}
-          DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_API_KEY: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_API_KEY }}
+          discord-guild-id: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID }}
+          discord-bot-token: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN }}
+          discord-application-id: ${{ secrets.DISCORD_EVENTS_SYNC_DISCORD_APPLICATION_ID }}
+          google-calendar-id: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_CALENDAR_ID }}
+          google-api-key: ${{ secrets.DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,33 @@
 
 🔁 Sync Google Calendar events to Discord Scheduled Events.
 
-🤖 Designed to run as a scheduled job in GitHub Actions.
+🤖 Designed to run as a scheduled job in GitHub Actions as a GitHub Action.
+
+## Getting Started
+
+```yml
+# .github/workflows/calsync.yml
+name: calsync
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: 🔁 Sync Events
+    steps:
+      - uses: acm-uic/calsync@main
+        with:
+          discord-guild-id: ${{ secrets.DISCORD_GUILD_ID }}
+          discord-bot-token: ${{ secrets.DISCORD_BOT_TOKEN }} # needs "Read Messages/View Channels", "Manage Events" permissions
+          discord-application-id: ${{ secrets.DISCORD_APPLICATION_ID }}
+          google-calendar-id: ${{ secrets.GOOGLE_CALENDAR_CALENDAR_ID }}
+          google-api-key: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+
+```
 
 ## How does it work?
 
@@ -21,4 +47,4 @@ variables or in `.env.` file in the root of the repository.
 
 ## Discord bot permissions
 
-The Discord bot needs permissions to view channels, and to manage events.
+The Discord bot needs "Read Messages/View Channels", "Manage Events" permissions.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,30 @@
+name: 'calsync'
+inputs:
+  discord-guild-id:
+    required: true
+  discord-bot-token:
+    required: true
+  discord-application-id:
+    required: true
+  google-calendar-id:
+    required: true
+  google-api-key:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Deno 🔧
+      uses: denoland/setup-deno@v1
+      with:
+        deno-version: v1.x
+
+    - name: Run sync 🔁
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: deno run --allow-net --allow-env --allow-read ./mod.ts
+      env:
+        DISCORD_EVENTS_SYNC_DISCORD_GUILD_ID: ${{ inputs.discord-guild-id }}
+        DISCORD_EVENTS_SYNC_DISCORD_BOT_TOKEN: ${{ inputs.discord-bot-token }}
+        DISCORD_EVENTS_SYNC_DISCORD_APPLICATION_ID: ${{ inputs.discord-application-id }}
+        DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_CALENDAR_ID: ${{ inputs.google-calendar-id }}
+        DISCORD_EVENTS_SYNC_GOOGLE_CALENDAR_API_KEY: ${{ inputs.google-api-key }}


### PR DESCRIPTION
Run as a github action to make it reusable without the need to fork the repo.

closes #42 